### PR TITLE
Validation for EMAIL_MAIL_PLAIN and EMAIL_MAIL_HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ EMAIL_PAGE_TEMPLATE = 'confirm_template.html'
 EMAIL_PAGE_DOMAIN = 'http://mydomain.com/'
 ```
 In detail:
-+ `EMAIL_ACTIVE_FIELD`: the user model filed which will be set to `True` once the email is confirmed
++ `EMAIL_ACTIVE_FIELD`: the user model field which will be set to `True` once the email is confirmed
 + `EMAIL_SERVER`: your mail provider's server (e.g. `'smtp.gmail.com'` for gmail)
 + `EMAIL_PORT`: your mail provider's server port (e.g. `587` for gmail)
 + `EMAIL_ADDRESS`: your email address
@@ -113,7 +113,7 @@ def myCreateView(request):
     sendConfirm(user)
     return render(...)
 ```
-`sendConfirm(user)` sets user's `is_active` to `False` and sends an email with the defined template (and the pseudo-random generated token) to the user.
+`sendConfirm(user)` sets user's `EMAIL_ACTIVE_FIELD` to `False` and sends an email with the defined template (and the pseudo-random generated token) to the user.
 
 ## Token verification
 You have to include the urls in `urls.py`


### PR DESCRIPTION
Even though there is try except, render_to_string() gives an error when we do not specify `EMAIL_TO_PLAIN` in settings.py and the program stops hence unable to successfully send the email. Therefore I've added some validation for both EMAIL_MAIL_PLAIN and EMAIL_MAIL_HTML fields and conditions to use them only when they are provided by the user.

<img width="441" alt="Screenshot 2020-06-18 at 02 34 49" src="https://user-images.githubusercontent.com/19875783/84950280-498e2e00-b10c-11ea-8f20-7fb36b40b7f9.png">

Also made a minor change in README file and fixed a typo.
