### PR TITLE
Update Confirm.py

### DIFF
--- a/django_email_verification/Confirm.py
+++ b/django_email_verification/Confirm.py
@@ -110,7 +110,7 @@ def verifyToken(email, email_token):
                 setattr(user, active_field, True)
                 user.last_login = timezone.now()
                 user.save()
-            return valid
+                return valid
     except b64Error:
         pass
     return False


### PR DESCRIPTION
Changed verifyToken() so that it will when multiple users have the same email address. This is done because the standard user model with django doesn't require the email to be unique.

I had to change this to get my django site to work when I was testing. 