### PR TITLE
Commented out what looks to be a leftover debug statement

### DIFF
--- a/django_email_verification/Confirm.py
+++ b/django_email_verification/Confirm.py
@@ -90,7 +90,7 @@ def sendConfirm_thread(email, token):
 def validateAndGetField(field, raise_error=True, default_type=str):
     try:
         d = getattr(settings, field)
-        print(field, d)
+        #print(field, d)
         if d == "" or d is None or not isinstance(d, default_type):
             raise AttributeError
         return d


### PR DESCRIPTION
My screen gets filled with the email settings variable when i try to run tests which can be annoying. They look like they are from this print statement which looks like a leftover debug statement so I commented it out.