### PR TITLE
Support for specifying custom user model through settings.py 

### DIFF
--- a/django_email_verification/Confirm.py
+++ b/django_email_verification/Confirm.py
@@ -3,6 +3,7 @@ from binascii import Error as b64Error
 from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
 from django.contrib.auth.tokens import default_token_generator
+from django.db.models import Model
 from django.template.loader import render_to_string
 from django.urls import get_resolver
 from django.utils import timezone
@@ -100,7 +101,10 @@ def validateAndGetField(field, raise_error=True, default_type=str):
 
 def verifyToken(email, email_token):
     try:
-        users = get_user_model().objects.filter(email=urlsafe_b64decode(email).decode("utf-8"))
+        user_model = validateAndGetField('EMAIL_USER_MODEL', raise_error=False, default_type=Model)
+        if user_model is None:
+            user_model = get_user_model()
+        users = user_model.objects.filter(email=urlsafe_b64decode(email).decode("utf-8"))
         for user in users:
             valid = default_token_generator.check_token(user, email_token)
             if valid:


### PR DESCRIPTION
# Why?
When I setup my authentication, I took a simple approach by using the default user class and created a model that extends it for any extra special attributes.

Your code depended mainly on `get_user_model()` to get the user model where `EMAIL_ACTIVE_FIELD` exists, which will fail in my case because it will return the default `User` model, not the extension model that I created which contains the `EMAIL_ACTIVE_FIELD`

I put a little extension to your code in this PR to support an extra settings field called `EMAIL_USER_MODEL`.
When this fields is specified, the model defined in it is used for setting the value of `EMAIL_ACTIVE_FIELD`, otherwise the code falls back to `get_user_model()`. 

Because the code at some point requires the an actual user model, another filed called `EMAIL_USER_MODEL_FK` is required which is the name of the property that points to an actual user model.

# Example
`UserData`
```py
class UserData(models.Model):
    user = models.ForeignKey(User, related_name="data", on_delete=models.CASCADE)
    email_verified = models.BooleanField(default=True)
```
`settings.py`
```py
EMAIL_USER_MODEL_FK = "user"
EMAIL_USER_MODEL = "xauth.UserData"
EMAIL_ACTIVE_FIELD = 'email_verified'
EMAIL_SERVER = 'smtp.gmail.com'
EMAIL_PORT = 587
...
```
when the user has just registered, an instance of the custom model is supplied instead of the actual user model
```py
def create(self, validated_data):
   user = User.objects.create_user(**validated_data['user'])
   user_data = UserData.objects.create(user=user, email_verified=False)
   sendConfirm(user_data)
```
And everything else just works.

# Notes
The code will fallback to normal behavior when `EMAIL_USER_MODEL` is not supplied 