### PR TITLE
changed custom salt option to settings variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,12 @@ You can use all the django email backends and also your custom one.
 
 ## Custom salt for token generation
 
-Pass the custom_salt keyword parameter to the `send_confirm` method as follows:
+You can define a custom salt to be used in token generation in your settings file.  Simply define:
 
 ```python
-send_email(user, custom_salt=my_custom_key_salt)
+CUSTOM_SALT = 'xxxxxxxxxxxxxxxxxxxxxxx'
 ```
-
+in your settings.py. 
 
 
 ### Logo copyright:

--- a/django_email_verification/confirm.py
+++ b/django_email_verification/confirm.py
@@ -15,9 +15,6 @@ def send_email(user, thread=True, **kwargs):
     try:
         user.save()
 
-        if kwargs.get('custom_salt'):
-            default_token_generator.key_salt = kwargs['custom_salt']
-
         expiry_ = kwargs.get('expiry')
         token, expiry = default_token_generator.make_token(user, expiry_)
 

--- a/django_email_verification/token.py
+++ b/django_email_verification/token.py
@@ -41,7 +41,10 @@ class EmailVerificationTokenGenerator:
     Strategy object used to generate and check tokens for the password
     reset mechanism.
     """
-    key_salt = "django-email-verification.token"
+    try:
+         key_salt = settings.CUSTOM_SALT
+    except AttributeError:
+         key_salt = "django-email-verification.token"
     algorithm = None
     secret = settings.SECRET_KEY
 


### PR DESCRIPTION
As discussed in issue #33 the custom salt cannot be generated dynamically or checking the token fails.

To remedy this, I have added an option to reference a CUSTOM_SALT variable in settings.py that defines a custom salt.

Ideally, there should be a custom salt for each password request, probably by using uuid,uuid4() to generate a salt, and then storing it in a field on the database against the USER table, to retrieve when checking the token.  However, that would mean a serious change to the code base.

In the meantime, I have stripped out the not-working-code and replaced it with the working settings.py arrangement.  I am quite happy to create the per-user-salt as described above, and to make a pull request, if you would like.