### PR TITLE
Support reactivation for multiple users with the same email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ EMAIL_MAIL_PLAIN = 'mail_body.txt'
 EMAIL_MAIL_TOKEN_LIFE = 60 * 60
 EMAIL_MAIL_PAGE_TEMPLATE = 'confirm_template.html'
 EMAIL_PAGE_DOMAIN = 'http://mydomain.com/'
-EMAIL_MULTI_USER = True  # optional (defaults to False)
 
 # For Django Email Backend
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
@@ -89,8 +88,6 @@ In detail:
 + `EMAIL_TOKEN_LIFE`: the lifespan of the email link (in seconds).
 + `EMAIL_PAGE_TEMPLATE`: the template of the success/error view.
 + `EMAIL_PAGE_DOMAIN`: the domain of the confirmation link (usually your site's domain).
-+ `EMAIL_MULTI_USER`: (optional) if `True` an error won't be thrown if multiple users with the same email are present (
-  just one will be activated)
 
 For the Django Email Backend fields look at the
 official [documentation](https://docs.djangoproject.com/en/3.1/topics/email/).

--- a/django_email_verification/tests/tests.py
+++ b/django_email_verification/tests/tests.py
@@ -236,7 +236,6 @@ def test_email_link_wrong_user(test_user, client, mailoutbox, wrong_token_templa
     response = client.get(url)
     assert response.content.decode() == wrong_token_template
 
-    settings.EMAIL_MULTI_USER = True
     test_user.is_active = False
     send_email(test_user, thread=False)
     email = mailoutbox[0]
@@ -268,7 +267,6 @@ def test_token_expired(test_user, mailoutbox, settings, client, wrong_token_temp
 
 @pytest.mark.django_db
 def test_multi_user(mailoutbox, settings, client):
-    setattr(settings, 'EMAIL_MULTI_USER', True)
     test_user_1 = get_user_model().objects.create(username='test_user_1', password='test_passwd_1',
                                                   email='test@test.com')
     test_user_2 = get_user_model().objects.create(username='test_user_2', password='test_passwd_2',
@@ -277,14 +275,14 @@ def test_multi_user(mailoutbox, settings, client):
     test_user_2.is_active = False
     test_user_1.save()
     test_user_2.save()
-    send_email(test_user_1, thread=False)
+    send_email(test_user_2, thread=False)
     email = mailoutbox[0]
     email_content = email.alternatives[0][0]
     url, _ = get_mail_params(email_content)
     response = client.get(url)
-    match = render_to_string('confirm.html', {'success': True, 'user': test_user_1})
+    match = render_to_string('confirm.html', {'success': True, 'user': test_user_2})
     assert response.content.decode() == match
-    assert list(get_user_model().objects.filter(email='test@test.com').values_list('is_active')) == [(True,), (False,)]
+    assert list(get_user_model().objects.filter(email='test@test.com').values_list('is_active')) == [(False,), (True,)]
 
 
 @pytest.mark.urls('django_email_verification.tests.urls_test_1')


### PR DESCRIPTION
These changes add the user ID to the token payload, so that the specific user can be identified for reactivation upon clicking the link. This way, the email address does not have to be unique among all users.

The EMAIL_MULTI_USER setting is removed, since it is no longer necessary to decide whether to allow email address to be non-unique.